### PR TITLE
Fixed the example code in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ var fs = require('fs');
 var parser = require('scratch-parser');
 
 var buffer = fs.readFileSync('/path/to/project.sb2');
-parser(buffer, function (err, project) {
+parser(buffer, false, function (err, project) {
     if (err) // handle the error
     // do something interesting
 });


### PR DESCRIPTION
The second parameter of parse determines whether the given buffer contains a sprite or a project.